### PR TITLE
fix(forestSpirit): ignore spectators from grow ability

### DIFF
--- a/src/main/java/io/github/mal32/endergames/kits/ForestSpirit.java
+++ b/src/main/java/io/github/mal32/endergames/kits/ForestSpirit.java
@@ -176,6 +176,7 @@ public class ForestSpirit extends AbstractKit {
       if (!(nearby instanceof LivingEntity living)) continue;
       if (living.equals(caster)) continue;
       if (living.isDead()) continue;
+      if (living instanceof Player player && player.getGameMode() == GameMode.SPECTATOR) continue;
       targets.add(living);
     }
 


### PR DESCRIPTION
needs to be tested with at least 3 players